### PR TITLE
Update documentation URL

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - uses: dswistowski/surge-sh-action@v1
         with:
-          domain: envisio-styleguide.surge.sh
+          domain: envisio-envy-ui.surge.sh
           project: './dist'
           login: ${{ secrets.SURGE_LOGIN }}
           token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '24'
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - run: npm i --legacy-peer-deps
       - run: npm run run-all
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: npm publish
       - uses: dswistowski/surge-sh-action@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  id-token: write  # Required for OIDC for npm Trusted Publishing
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,8 +23,6 @@ jobs:
       - run: npm run run-all
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - uses: dswistowski/surge-sh-action@v1
         with:
           domain: envisio-envy-ui.surge.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
           login: ${{ secrets.SURGE_LOGIN }}
           token: ${{ secrets.SURGE_TOKEN }}
       - run: |
-          echo "current_version=$(echo $(npm view envy-ui version))" >> "$GITHUB_ENV"
+          echo "current_version=$(echo $(npm view @envisio/envy-ui version))" >> "$GITHUB_ENV"
       - run: |
           curl -X POST \
           -H 'Content-type: application/json' \

--- a/backstop.config_new.js
+++ b/backstop.config_new.js
@@ -101,8 +101,8 @@ const sharedScenarioData = {
 const getURLS = ({section = ''}) => (
   {
     "url": `http://localhost:5000/dist/styleguide/${section}.html`,
-    // "url": `http://envisio-styleguide.surge.sh/styleguide/${section}.html`,
-    "referenceUrl": `http://envisio-styleguide.surge.sh/styleguide/${section}.html`,
+    // "url": `http://envisio-envy-ui.surge.sh/styleguide/${section}.html`,
+    "referenceUrl": `http://envisio-envy-ui.surge.sh/styleguide/${section}.html`,
   }
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "envy-ui",
+  "name": "@envisio/envy-ui",
   "version": "1.0.484",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "envy-ui",
+      "name": "@envisio/envy-ui",
       "version": "1.0.484",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@envisio/envy-ui",
-  "version": "1.0.484",
+  "version": "1.0.485",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@envisio/envy-ui",
-      "version": "1.0.484",
+      "version": "1.0.485",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "envy-ui",
+  "name": "@envisio/envy-ui",
   "version": "1.0.484",
   "description": "UI Design System for Envisio Applications",
   "main": "./lib/index.js",
@@ -52,13 +52,13 @@
     "specificity": "specificity-graph dist/css/ui.css --output dist/styleguide/specificity",
     "render-styleguide-homepage": "pug -O src/javascripts/from-dictionary/block_name.styleguide.js styleguide/homepage/styleguide-homepage.pug --extension md --pretty --out styleguide/",
     "render-markups": "pug --pretty -O src/javascripts/from-dictionary/block_name.styleguide.js src/stylesheets/a/kss/src/ --out src/stylesheets/a/kss/build/",
-    "deploy": "npm run specificity && surge --domain envisio-styleguide.surge.sh ./dist",
+    "deploy": "npm run specificity && surge --domain envisio-envy-ui.surge.sh ./dist",
     "js-test": "babel-tape-runner src/javascripts/ui/tests/get_block.test.js | faucet",
     "backstop:exec-test": "concurrently \"http-server -a localhost -p 5000\" \"sleepms 2000 && node backstop.exec.js test; open-cli http://localhost:5000/backstop_data/html_report/\"",
     "backstop:reference": "backstop reference --config=\"backstop.config.js\"",
     "start:styleguide": "npm run open-styleguide",
     "open-styleguide": "concurrently \"http-server -a localhost -c-1 -p 1234\" \"open http://localhost:1234/dist/styleguide/\"",
-    "publish-staging": "npm run run-all && surge ./dist envisio-styleguide-staging.surge.sh"
+    "publish-staging": "npm run run-all && surge ./dist envisio-envy-ui-staging.surge.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envisio/envy-ui",
-  "version": "1.0.484",
+  "version": "1.0.485",
   "description": "UI Design System for Envisio Applications",
   "main": "./lib/index.js",
   "files": [


### PR DESCRIPTION
This pull request updates the project to use the new `envisio-envy-ui` naming convention across deployment, configuration, and publishing scripts. The changes ensure consistency in naming and update all relevant deployment URLs and package identifiers.

**Deployment and URL updates:**

* Changed the Surge deployment domain from `envisio-styleguide.surge.sh` to `envisio-envy-ui.surge.sh` in the GitHub Actions workflow (`.github/workflows/publish.yml`).
* Updated all references to the styleguide's Surge domain in `backstop.config_new.js` to use `envisio-envy-ui.surge.sh` for visual regression testing.
* Modified the `deploy` and `publish-staging` scripts in `package.json` to use the new Surge domains (`envisio-envy-ui.surge.sh` and `envisio-envy-ui-staging.surge.sh`).

**Package naming:**

* Renamed the package from `envy-ui` to `@envisio/envy-ui` in `package.json` to follow scoped package naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment setup to publish the package to new hosting domains and added a dedicated deployment step in CI
  * Enabled OIDC id-token writing in the CI workflow and published under a scoped package name with a version bump

* **Tests**
  * Updated visual/regression test configuration to reference the new styleguide host
<!-- end of auto-generated comment: release notes by coderabbit.ai -->